### PR TITLE
Fix fetchFavorites error handling

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -10,6 +10,7 @@ import {
   ADD_FAVORITE,
   REMOVE_FAVORITE,
   FETCH_FAVORITES,
+  FETCH_FAVORITES_ERROR,
   RECEIVE_FAVORITES,
   ADD_MESSAGE,
   REMOVE_MESSAGE
@@ -86,6 +87,8 @@ export const fetchFavorites = () => async dispatch => {
   if (!res.data.error) {
     dispatch({ type: RECEIVE_FAVORITES, payload: res.data });
   }
+
+  dispatch({ type: FETCH_FAVORITES_ERROR });
 };
 
 export const updateMessages = (index, message) => async dispatch => {

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -5,6 +5,7 @@ export const ADD_FAVORITE = 'add-favorite';
 export const REMOVE_FAVORITE = 'remove-favorite';
 export const FETCH_FAVORITES = 'fetch-favorites';
 export const RECEIVE_FAVORITES = 'receive-favorites';
+export const FETCH_FAVORITES_ERROR = 'fetch-favorites-error';
 export const ADD_MESSAGE = 'add-message';
 export const REMOVE_MESSAGE = 'remove-message';
 export const FETCH_DESTINATION = 'fetch-destination';

--- a/client/src/reducers/favoritesReducer.js
+++ b/client/src/reducers/favoritesReducer.js
@@ -2,7 +2,8 @@ import {
   ADD_FAVORITE,
   REMOVE_FAVORITE,
   FETCH_FAVORITES,
-  RECEIVE_FAVORITES
+  RECEIVE_FAVORITES,
+  FETCH_FAVORITES_ERROR
 } from '../actions/types';
 
 const initialState = {
@@ -33,6 +34,10 @@ export default function(state = initialState, action) {
       return Object.assign({}, state, {
         isFetching: false,
         ...action.payload
+      });
+    case FETCH_FAVORITES_ERROR:
+      return Object.assign({}, state, {
+        isFetching: false
       });
     default:
       return state;


### PR DESCRIPTION
The Redux action did not handle resetting isFetching to false if the
backend returned an error. This resulted in a user seeing the loader if
they went to favorites after registering for an account. There is now an
error type which resets isFetching back to false.